### PR TITLE
Fix sidebar open state, sidebar width and settings panel

### DIFF
--- a/src/containers/SettingsPanel.tsx
+++ b/src/containers/SettingsPanel.tsx
@@ -87,7 +87,8 @@ export const SettingsPanel = () => {
     setSideBarWidth(value);
   }, SETTINGS_DEBOUNCE_TIME);
   const setSideBarOpacityDebounced = _.debounce((value: any) => {
-    if (value == 100) value = 99.99; // Avoid
+    // Set to 99.99 because a value of 100 seems to have problems re-rendering
+    if (value == 100) value = 99.99;
     log.debug(`Setting opacity to ${value}`);
     setSideBarOpacity(value);
   }, SETTINGS_DEBOUNCE_TIME);
@@ -107,9 +108,9 @@ export const SettingsPanel = () => {
           <div>Sidebar Width</div>
           <div className="flex w-full flex-col space-y-8">
             <Slider.Root
-              min={20}
-              max={48}
-              step={1}
+              min={300}
+              max={640}
+              step={4}
               defaultValue={[sideBarWidth]}
               className="relative flex h-4 select-none items-center"
               onValueChange={setSideBarWidthDebounced}

--- a/src/pages/Content/index.js
+++ b/src/pages/Content/index.js
@@ -140,7 +140,7 @@ const App = () => {
       // Now we check local storage for tab state, otherwise return default val
       chrome.storage.local.get([tabOpenClosedStateStorageKey], (result) => {
         const shouldTabBeOpen =
-          result[tabOpenClosedStateStorageKey] ||
+          result[tabOpenClosedStateStorageKey] ??
           DEFAULT_SIDEBAR_OPEN_TAB_STATE;
         log.debug(`Sidebar should be open? ${shouldTabBeOpen}`);
         setUserOpenedSideBar(shouldTabBeOpen);
@@ -158,8 +158,10 @@ const App = () => {
   // UI should call this to update sidebar state if it needs to be toggled somehow
   // The storage will update too.
   const toggleUserOpenedSidebarStateWithStorage = () => {
-    setUserOpenedSideBar((show) => !show);
-    updateStorageWithOpenClosedState(!userOpenedSideBar);
+    setUserOpenedSideBar((show) => {
+      updateStorageWithOpenClosedState(!show);
+      return !show;
+    });
   };
 
   // Actually updates storage about the open-closed state

--- a/src/pages/Content/index.js
+++ b/src/pages/Content/index.js
@@ -222,7 +222,7 @@ const App = () => {
       <iframe
         title="sidebar-iframe"
         style={{
-          width: shouldShowSideBar ? `${sideBarWidth}rem` : "0",
+          width: shouldShowSideBar ? `${sideBarWidth}px` : "0",
           height: "100vh",
           border: "none",
           borderSizing: "border-box",
@@ -258,6 +258,7 @@ const App = () => {
             style={{
               height: "64px",
               width: "64px",
+              cursor: "pointer",
               top: "0",
               position: "absolute",
             }}

--- a/src/pages/Sidebar/Sidebar.css
+++ b/src/pages/Sidebar/Sidebar.css
@@ -1,5 +1,5 @@
 .loader {
-  border-top-color: #3498db;
+  border-top-color: #4F46E5;
   -webkit-animation: spinner 1.5s linear infinite;
   animation: spinner 1.5s linear infinite;
 }

--- a/src/pages/Sidebar/Sidebar.tsx
+++ b/src/pages/Sidebar/Sidebar.tsx
@@ -30,7 +30,8 @@ const EmptyDiscussionsState = () => (
     />
     <div className="text-center text-base font-semibold">No discussions</div>
     <div className="text-center text-slate-500">
-      We can't find any relevant discussions on this page.
+      We can't find any relevant discussions on this web page, try going to a
+      different web page.
     </div>
   </>
 );
@@ -43,7 +44,8 @@ const Sidebar = () => {
     hackerNews: [],
     reddit: [],
   });
-  const [isUpdatingResults, setIsUpdatingResults] = useState<boolean>(false);
+  const [isLoadingProviderData, setIsLoadingProviderData] =
+    useState<boolean>(false);
 
   const [hotkeysToggleSidebar, setHotkeysToggleSidebar] = useChromeStorage(
     KEY_HOTKEYS_TOGGLE_SIDEBAR,
@@ -61,13 +63,13 @@ const Sidebar = () => {
 
   // Actual call to update current results
   const updateProviderData = () => {
-    setIsUpdatingResults(true);
+    setIsLoadingProviderData(true);
     log.debug("Sending message to background script to update provider info.");
     chrome.runtime.sendMessage(
       { getProviderData: true },
       (results: ProviderResults) => {
         // Received results from providers
-        setIsUpdatingResults(false);
+        setIsLoadingProviderData(false);
         log.debug("Printing provider data from background script...");
         log.debug(results);
         setProviderData(results);
@@ -114,7 +116,7 @@ const Sidebar = () => {
 
   return (
     <div className="flex h-full w-full flex-row">
-      {isUpdatingResults && (
+      {isLoadingProviderData && (
         <div className="fixed top-0 left-0 right-0 bottom-0 z-50 flex h-screen w-full flex-col items-center justify-center overflow-hidden bg-gray-700 opacity-75">
           <div className="loader mb-4 h-12 w-12 rounded-full border-4 border-t-4 ease-linear" />
           <h2 className="text-center text-xl font-semibold text-white">
@@ -158,7 +160,7 @@ const Sidebar = () => {
                     leaveFrom="opacity-100 translate-y-0"
                     leaveTo="opacity-0 translate-y-1"
                   >
-                    <Popover.Panel className="absolute right-0 z-10 mt-3 w-screen max-w-xs transform px-4 sm:px-0 lg:max-w-3xl">
+                    <Popover.Panel className="absolute -right-8 z-10 mt-3 w-screen max-w-xs transform px-4 sm:px-0 lg:max-w-3xl">
                       <SettingsPanel />
                     </Popover.Panel>
                   </Transition>

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -5,7 +5,7 @@ export const APP_NAME_FULL = "Vertical Tabs";
 export const SIDEBAR_CONTAINER_ID = `${APP_NAME_SHORT}-sidebar-container`;
 
 export const SETTINGS_DEBOUNCE_TIME = 400;
-export const DEFAULT_SIDEBAR_WIDTH = 24; // rem
+export const DEFAULT_SIDEBAR_WIDTH = 360; // px
 export const DEFAULT_SIDEBAR_OPACITY = 95; // Divided by 100
 export const DEFAULT_HIDE_CONTENT_BUTTON = false;
 export const DEFAULT_CONTENT_BUTTON_BACKGROUND = false;
@@ -32,5 +32,5 @@ export const KEY_SIDEBAR_OPEN_TAB_STATE = "sidebar-open-tab-state";
 export const CACHE_URL_DURATION_SEC = 120;
 export const CACHE_CLEAR_URL_ALARM_INTERVAL_MIN = 1;
 export const CACHE_CLEAR_TABID_ALARM_INTERVAL_MIN = 5;
-export const CACHE_CLEAR_URL_ALARM_NAME = "refresh_url_cache"
-export const CACHE_CLEAR_TABID_ALARM_NAME = "refresh_tabid_cache"
+export const CACHE_CLEAR_URL_ALARM_NAME = "refresh_url_cache";
+export const CACHE_CLEAR_TABID_ALARM_NAME = "refresh_tabid_cache";


### PR DESCRIPTION
Fixed:
- Sidebar open state is not being persisted correctly because wrong state is saved to chrome storage.
- Previous sidebar width was expressed in `rem`, this results in different widths for different webpages since `rem` means different sizes for each web page. Changing to `px` leads to the width being absolute.
- Settings panel is too big when sidebar width is at the smallest.

Addresses #47 