### PR TITLE
Fix bug where results badge and spinner do not track the extension button and other bugs

### DIFF
--- a/src/containers/ResultCard.tsx
+++ b/src/containers/ResultCard.tsx
@@ -27,7 +27,7 @@ const ResultCard = (props: Props) => {
           </div>
         </div>
       )}
-      <div className="text-md font-medium text-blue-800 hover:underline">
+      <div className="text-md font-medium text-indigo-600 hover:underline">
         <a
           href={result.commentsLink}
           target="_blank"

--- a/src/pages/Content/index.js
+++ b/src/pages/Content/index.js
@@ -253,9 +253,8 @@ const App = () => {
               color={"rgba(163,163,163,0.5)"}
               css={{
                 display: "block",
-                position: "fixed",
-                bottom: "64px",
-                right: "16px",
+                position: "absolute",
+                right: "0",
               }}
               loading={isLoadingResults}
               size={20}
@@ -266,9 +265,8 @@ const App = () => {
             <div
               className="allUnset animate__animated animate__heartBeat"
               style={{
-                position: "fixed",
-                bottom: "64px",
-                right: "16px",
+                position: "absolute",
+                right: "0",
                 textAlign: "center",
                 fontSize: "12px",
                 minWidth: "8px",

--- a/src/pages/Content/index.js
+++ b/src/pages/Content/index.js
@@ -201,28 +201,32 @@ const App = () => {
     hotkeysToggleSidebar.join(", ").replaceAll("+", " + ") +
     "  (Go settings to hide button)";
 
-  const contentButtonPlacementCss = {
-    "top-left": {
-      top: DEFAULT_CONTENT_BUTTON_PLACEMENT_OFFSET,
-      left: DEFAULT_CONTENT_BUTTON_PLACEMENT_OFFSET,
-    },
-    "top-right": {
-      top: DEFAULT_CONTENT_BUTTON_PLACEMENT_OFFSET,
-      right: DEFAULT_CONTENT_BUTTON_PLACEMENT_OFFSET,
-    },
-    "bottom-left": {
-      bottom: DEFAULT_CONTENT_BUTTON_PLACEMENT_OFFSET,
-      left: DEFAULT_CONTENT_BUTTON_PLACEMENT_OFFSET,
-    },
-    "bottom-right": {
-      bottom: DEFAULT_CONTENT_BUTTON_PLACEMENT_OFFSET,
-      right: DEFAULT_CONTENT_BUTTON_PLACEMENT_OFFSET,
-    },
-  }[
+  // Hide content button when we have not fetched its position. If we gave
+  // a default placement (e.g. bottom-right), then there will be "flashing"
+  // problems if the user has already specified a different placement
+  // (e.g. top-left) where the button appears briefly at the bottom-right
+  // and then goes to the top-left.
+  const contentButtonPlacementCss =
     contentButtonPlacement === null
-      ? "bottom-right"
-      : contentButtonPlacement.key
-  ];
+      ? { display: "none" }
+      : {
+          "top-left": {
+            top: DEFAULT_CONTENT_BUTTON_PLACEMENT_OFFSET,
+            left: DEFAULT_CONTENT_BUTTON_PLACEMENT_OFFSET,
+          },
+          "top-right": {
+            top: DEFAULT_CONTENT_BUTTON_PLACEMENT_OFFSET,
+            right: DEFAULT_CONTENT_BUTTON_PLACEMENT_OFFSET,
+          },
+          "bottom-left": {
+            bottom: DEFAULT_CONTENT_BUTTON_PLACEMENT_OFFSET,
+            left: DEFAULT_CONTENT_BUTTON_PLACEMENT_OFFSET,
+          },
+          "bottom-right": {
+            bottom: DEFAULT_CONTENT_BUTTON_PLACEMENT_OFFSET,
+            right: DEFAULT_CONTENT_BUTTON_PLACEMENT_OFFSET,
+          },
+        }[contentButtonPlacement.key];
 
   return (
     <div className="allUnset">

--- a/src/pages/Sidebar/Sidebar.tsx
+++ b/src/pages/Sidebar/Sidebar.tsx
@@ -231,7 +231,7 @@ const Sidebar = () => {
           )}
 
           <div className="space-y-3 p-3 text-left">
-            <p className="text-lg text-blue-700">Discussions</p>
+            <p className="text-lg text-indigo-600">Discussions</p>
             {noDiscussions ? (
               <EmptyDiscussionsState />
             ) : (


### PR DESCRIPTION
Adjustments:
- Change text-blue-X to text-indigo-X

Fixed bugs:
- Results badge and spinner do not track the extension button when moving extension button away from the bottom right placement
- Extension button will flash briefly if it is placed away from bottom right because a default value of bottom right was given while we are loading settings